### PR TITLE
Branch 77 - suppress error messages once users log out

### DIFF
--- a/frontend/cheapchess/src/pages/Game.js
+++ b/frontend/cheapchess/src/pages/Game.js
@@ -309,6 +309,11 @@ const Game = () =>
 
   /* Whenever gameDataFromServer changes, update boardData (will update UI). */
   useEffect(() => {
+    /* Create 'active' variable for clean-up up purposes.
+       It will ensure that state setters are not called
+       if the app is closed while an async process is executing */
+    let active = true;
+
     if (
       gameDataFromServer &&
       boardData &&
@@ -358,7 +363,7 @@ const Game = () =>
       ) {
       setTimeout(() => {
         appState.imports.continueGame(gameDataFromServer.id, {}, setMessages).then((continuedGameData) => {
-          if (continuedGameData?.pieces) {
+          if (continuedGameData?.pieces && active) {
             const updatedContinuedGameData = appState.imports.updateIconURLs(continuedGameData, iconData);
             setGameDataFromServer(updatedContinuedGameData);
           }

--- a/frontend/cheapchess/src/utils/api_ContinueGame.js
+++ b/frontend/cheapchess/src/utils/api_ContinueGame.js
@@ -22,8 +22,15 @@ const continueGame = async (gameID, formData, setMessages) => {
     );
     return await response.data;
   } catch (e) {
+    /* It is possible for a user to logout after a game data
+       refresh timeout has been set in Game.js.  If this happens,
+       the backend will return an error 403 since the user
+       is no longer authenticated by the time the fetch request
+       is called. No need to display an error message in that case. */
+    if (e?.response?.status !== 403) {
+      setMessages(getResponseError(e));
+    }
     console.log(e);
-    setMessages(getResponseError(e));
   }
 };
 


### PR DESCRIPTION
Completed in accordance with issue specification.  It appears the function to be called is established at the moment a timeout is set (including all state/variables at that time), so if one of those variables change (i.e. auth.user) it doesn't appear the change is reflected in the function call after the timeout is reached.  So instead, I just checked for status 403 in the continueGame api call, and suppressed error messages from there.